### PR TITLE
Null move pruning

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -903,6 +903,18 @@ impl Board {
         }
     }
 
+    pub fn is_king_pawn(&self) -> bool {
+        for row in self.board.iter() {
+            for cell in row.iter() {
+                match cell.kind() {
+                    Piece::KNIGHT | Piece::BISHOP | Piece::ROOK | Piece::QUEEN => return false,
+                    _ => {}
+                }
+            }
+        }
+        true
+    }
+
     fn is_attacked(&self, pos: Position) -> bool {
         let helper = |offsets: [Position; 4], slide_attackers: [Piece; 2]| {
             for offset in offsets {

--- a/src/search.rs
+++ b/src/search.rs
@@ -222,20 +222,15 @@ impl Search {
             }
         }
 
+        // static eval
+        let stand_pat = score(&self.board);
+
         // null move
-        if depth > 3 && !self.board.is_check() {
+        if depth > 3 && stand_pat > beta && !self.board.is_king_pawn() && !self.board.is_check() {
             self.board.make_move(&Move::NULL_MOVE);
             let res = self.nega_max(-beta, -alpha, depth - 1 - 3, ply_from_root + 1, extensions);
             self.board.unmake_move(&Move::NULL_MOVE);
             if res.is_some_and(|score| -score >= beta) {
-                self.table.lock().unwrap().save(Entry {
-                    z_key: self.board.z_hash,
-                    best_move: Some(Move::NULL_MOVE),
-                    depth,
-                    score: -res.unwrap(),
-                    score_type: ScoreType::Beta,
-                    epoch: self.epoch,
-                });
                 return Some(beta);
             }
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use crate::board::{Board, Move, MoveList, MAX_MOVES};
+use crate::board::{Board, Move, MoveList, Piece, MAX_MOVES};
 use crate::score::{score, MATE};
 use crate::table::{Entry, ScoreType, Table};
 
@@ -146,9 +146,10 @@ impl Search {
                 best_move = depth_best_move;
                 max_depth = depth;
             }
+            let nodes_at_level = (self.nodes - before_nodes) as f64;
             self.writeln(format!(
                 "info string ebf {}",
-                f64::sqrt(self.nodes as f64 / (before_nodes + 1) as f64)
+                nodes_at_level.powf(1.0 / (depth + 1) as f64)
             ));
         }
         let table = self.table.lock().unwrap();
@@ -212,7 +213,30 @@ impl Search {
                     }
                 }
 
-                best_move = hit.best_move;
+                if hit
+                    .best_move
+                    .is_some_and(|mv| mv.piece != Piece::NULL_PIECE)
+                {
+                    best_move = hit.best_move;
+                }
+            }
+        }
+
+        // null move
+        if depth > 3 && !self.board.is_check() {
+            self.board.make_move(&Move::NULL_MOVE);
+            let res = self.nega_max(-beta, -alpha, depth - 1 - 3, ply_from_root + 1, extensions);
+            self.board.unmake_move(&Move::NULL_MOVE);
+            if res.is_some_and(|score| -score >= beta) {
+                self.table.lock().unwrap().save(Entry {
+                    z_key: self.board.z_hash,
+                    best_move: Some(Move::NULL_MOVE),
+                    depth,
+                    score: -res.unwrap(),
+                    score_type: ScoreType::Beta,
+                    epoch: self.epoch,
+                });
+                return Some(beta);
             }
         }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -148,6 +148,7 @@ impl Uci {
         let table = self.table.clone();
         thread::spawn(move || {
             let mut search = Search::new(board, tl, abort, table);
+
             match search.search() {
                 Some(best_move) => {
                     println!("bestmove {}", best_move);


### PR DESCRIPTION
```
Results of nmp vs base (10+0.1, NULL, 64MB, 8moves_v3.pgn):
Elo: 34.86 +/- 21.13, nElo: 57.34 +/- 34.48
LOS: 99.94 %, DrawRatio: 45.64 %, PairsRatio: 1.94
Games: 390, Wins: 99, Losses: 60, Draws: 231, Points: 214.5 (55.00 %)
Ptnml(0-2): [5, 31, 89, 60, 10], WL/DD Ratio: 0.27
LLR: 2.94 (-2.94, 2.94) [0.00, 20.00]
```