### PR TITLE
fix: eval bugs

### DIFF
--- a/src/score.rs
+++ b/src/score.rs
@@ -180,9 +180,9 @@ pub fn score(board: &Board) -> i32 {
     for (r_idx, row) in board.board.iter().enumerate() {
         for (c_idx, cell) in row.iter().enumerate() {
             let r_corr = if cell.side() == Piece::WHITE {
-                r_idx
-            } else {
                 7 - r_idx
+            } else {
+                r_idx
             };
             match cell.kind() {
                 Piece::PAWN => match cell.side() {


### PR DESCRIPTION
I'm an idiot. As expected, this has a huge impact

```
Results of alex/eval-fix vs main (10+0.1, 1t, 128MB, 8moves_v3.pgn):
Elo: 218.77 +/- 38.50, nElo: 292.54 +/- 39.71
LOS: 100.00 %, DrawRatio: 18.37 %, PairsRatio: 14.00
Games: 294, Wins: 190, Losses: 26, Draws: 78, Points: 229.0 (77.89 %)
Ptnml(0-2): [2, 6, 27, 50, 62]
LLR: 2.95 (-2.94, 2.94) [0.00, 10.00]
```