### PR TITLE
feat: updated piece square tables

### DIFF
--- a/src/score.rs
+++ b/src/score.rs
@@ -1,11 +1,5 @@
 use crate::board::{Board, Piece};
 
-// const PAWN_SCORE: i32 = 100;
-// const KNIGHT_SCORE: i32 = 320;
-// const BISHOP_SCORE: i32 = 330;
-// const ROOK_SCORE: i32 = 500;
-// const QUEEN_SCORE: i32 = 900;
-
 const PIECE_VALUES: [[i32; 6]; 2] = [
     [126, 781, 825, 1276, 2538, 0],
     [208, 854, 915, 1380, 2682, 0],

--- a/src/score.rs
+++ b/src/score.rs
@@ -170,61 +170,61 @@ pub fn score(board: &Board) -> i32 {
             match (cell.kind(), cell.side()) {
                 (Piece::PAWN, Piece::WHITE) => {
                     wpawns += 1;
-                    psqt_mg_score += PAWN_TABLE[0][r_idx][c_idx];
-                    psqt_eg_score += PAWN_TABLE[1][r_idx][c_idx];
-                }
-                (Piece::PAWN, Piece::BLACK) => {
-                    bpawns += 1;
                     psqt_mg_score += PAWN_TABLE[0][7 - r_idx][c_idx];
                     psqt_eg_score += PAWN_TABLE[1][7 - r_idx][c_idx];
                 }
+                (Piece::PAWN, Piece::BLACK) => {
+                    bpawns += 1;
+                    psqt_mg_score -= PAWN_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score -= PAWN_TABLE[1][r_idx][c_idx];
+                }
                 (Piece::KNIGHT, Piece::WHITE) => {
                     wknights += 1;
-                    psqt_mg_score += KNIGHT_TABLE[0][r_idx][c_idx];
-                    psqt_eg_score += KNIGHT_TABLE[1][r_idx][c_idx];
-                }
-                (Piece::KNIGHT, Piece::BLACK) => {
-                    bknights += 1;
                     psqt_mg_score += KNIGHT_TABLE[0][7 - r_idx][c_idx];
                     psqt_eg_score += KNIGHT_TABLE[1][7 - r_idx][c_idx];
                 }
+                (Piece::KNIGHT, Piece::BLACK) => {
+                    bknights += 1;
+                    psqt_mg_score -= KNIGHT_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score -= KNIGHT_TABLE[1][r_idx][c_idx];
+                }
                 (Piece::BISHOP, Piece::WHITE) => {
                     wbishops += 1;
-                    psqt_mg_score += BISHOP_TABLE[0][r_idx][c_idx];
-                    psqt_eg_score += BISHOP_TABLE[1][r_idx][c_idx];
-                }
-                (Piece::BISHOP, Piece::BLACK) => {
-                    bbishops += 1;
                     psqt_mg_score += BISHOP_TABLE[0][7 - r_idx][c_idx];
                     psqt_eg_score += BISHOP_TABLE[1][7 - r_idx][c_idx];
                 }
+                (Piece::BISHOP, Piece::BLACK) => {
+                    bbishops += 1;
+                    psqt_mg_score -= BISHOP_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score -= BISHOP_TABLE[1][r_idx][c_idx];
+                }
                 (Piece::ROOK, Piece::WHITE) => {
                     wrooks += 1;
-                    psqt_mg_score += ROOK_TABLE[0][r_idx][c_idx];
-                    psqt_eg_score += ROOK_TABLE[1][r_idx][c_idx];
-                }
-                (Piece::ROOK, Piece::BLACK) => {
-                    brooks += 1;
                     psqt_mg_score += ROOK_TABLE[0][7 - r_idx][c_idx];
                     psqt_eg_score += ROOK_TABLE[1][7 - r_idx][c_idx];
                 }
+                (Piece::ROOK, Piece::BLACK) => {
+                    brooks += 1;
+                    psqt_mg_score -= ROOK_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score -= ROOK_TABLE[1][r_idx][c_idx];
+                }
                 (Piece::QUEEN, Piece::WHITE) => {
                     wqueens += 1;
-                    psqt_mg_score += QUEEN_TABLE[0][r_idx][c_idx];
-                    psqt_eg_score += QUEEN_TABLE[1][r_idx][c_idx];
-                }
-                (Piece::QUEEN, Piece::BLACK) => {
-                    bqueens += 1;
                     psqt_mg_score += QUEEN_TABLE[0][7 - r_idx][c_idx];
                     psqt_eg_score += QUEEN_TABLE[1][7 - r_idx][c_idx];
                 }
-                (Piece::KING, Piece::WHITE) => {
-                    psqt_mg_score += KING_TABLE[0][r_idx][c_idx];
-                    psqt_eg_score += KING_TABLE[1][r_idx][c_idx];
+                (Piece::QUEEN, Piece::BLACK) => {
+                    bqueens += 1;
+                    psqt_mg_score -= QUEEN_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score -= QUEEN_TABLE[1][r_idx][c_idx];
                 }
-                (Piece::KING, Piece::BLACK) => {
+                (Piece::KING, Piece::WHITE) => {
                     psqt_mg_score += KING_TABLE[0][7 - r_idx][c_idx];
                     psqt_eg_score += KING_TABLE[1][7 - r_idx][c_idx];
+                }
+                (Piece::KING, Piece::BLACK) => {
+                    psqt_mg_score -= KING_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score -= KING_TABLE[1][r_idx][c_idx];
                 }
                 _ => {}
             }
@@ -261,5 +261,30 @@ pub fn score(board: &Board) -> i32 {
         score
     } else {
         -score
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::board::Board;
+    #[test]
+    fn test_score() {
+        let board = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+            .parse::<Board>()
+            .unwrap();
+        assert_eq!(score(&board), 0);
+    }
+
+    #[test]
+    fn test_single_pawn() {
+        let board = "8/8/8/8/8/8/P7/8 w - - 0 1".parse::<Board>().unwrap();
+        assert_eq!(score(&board), 221);
+    }
+
+    #[test]
+    fn test_single_pawn_black_turn() {
+        let board = "8/8/8/8/8/8/P7/8 b - - 0 1".parse::<Board>().unwrap();
+        assert_eq!(score(&board), -221);
     }
 }

--- a/src/score.rs
+++ b/src/score.rs
@@ -1,236 +1,261 @@
 use crate::board::{Board, Piece};
 
-const PAWN_SCORE: i32 = 100;
-const KNIGHT_SCORE: i32 = 320;
-const BISHOP_SCORE: i32 = 330;
-const ROOK_SCORE: i32 = 500;
-const QUEEN_SCORE: i32 = 900;
+// const PAWN_SCORE: i32 = 100;
+// const KNIGHT_SCORE: i32 = 320;
+// const BISHOP_SCORE: i32 = 330;
+// const ROOK_SCORE: i32 = 500;
+// const QUEEN_SCORE: i32 = 900;
 
-const PAWN_TABLE: [[i32; 8]; 8] = [
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [50, 50, 50, 50, 50, 50, 50, 50],
-    [10, 10, 20, 30, 30, 20, 10, 10],
-    [5, 5, 10, 25, 25, 10, 5, 5],
-    [0, 0, 0, 20, 20, 0, 0, 0],
-    [5, -5, -10, 0, 0, -10, -5, 5],
-    [5, 10, 10, -20, -20, 10, 10, 5],
-    [0, 0, 0, 0, 0, 0, 0, 0],
+const PIECE_VALUES: [[i32; 6]; 2] = [
+    [126, 781, 825, 1276, 2538, 0],
+    [208, 854, 915, 1380, 2682, 0],
 ];
 
-const PAWN_TABLE_ENDGAME: [[i32; 8]; 8] = [
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [80, 80, 80, 80, 80, 80, 80, 80],
-    [50, 50, 50, 50, 50, 50, 50, 50],
-    [30, 30, 30, 30, 30, 30, 30, 30],
-    [20, 20, 20, 20, 20, 20, 20, 20],
-    [10, 10, 10, 10, 10, 10, 10, 10],
-    [10, 10, 10, 10, 10, 10, 10, 10],
-    [0, 0, 0, 0, 0, 0, 0, 0],
+const PAWN_TABLE: [[[i32; 8]; 8]; 2] = [
+    [
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [98, 134, 61, 95, 68, 126, 34, -11],
+        [-6, 7, 26, 31, 65, 56, 25, -20],
+        [-14, 13, 6, 21, 23, 12, 17, -23],
+        [-27, -2, -5, 12, 17, 6, 10, -25],
+        [-26, -4, -4, -10, 3, 3, 33, -12],
+        [-35, -1, -20, -23, -15, 24, 38, -22],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ],
+    [
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [178, 173, 158, 134, 147, 132, 165, 187],
+        [94, 100, 85, 67, 56, 53, 82, 84],
+        [32, 24, 13, 5, -2, 4, 17, 17],
+        [13, 9, -3, -7, -7, -8, 3, -1],
+        [4, 7, -6, 1, 0, -5, -1, -8],
+        [13, 8, 8, 10, 13, 0, 2, -7],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ],
 ];
 
-const KNIGHT_TABLE: [[i32; 8]; 8] = [
-    [-50, -40, -30, -30, -30, -30, -40, -50],
-    [-40, -20, 0, 0, 0, 0, -20, -40],
-    [-30, 0, 10, 15, 15, 10, 0, -30],
-    [-30, 5, 15, 20, 20, 15, 5, -30],
-    [-30, 0, 15, 20, 20, 15, 0, -30],
-    [-30, 5, 10, 15, 15, 10, 5, -30],
-    [-40, -20, 0, 5, 5, 0, -20, -40],
-    [-50, -40, -30, -30, -30, -30, -40, -50],
+const KNIGHT_TABLE: [[[i32; 8]; 8]; 2] = [
+    [
+        [-167, -89, -34, -49, 61, -97, -15, -107],
+        [-73, -41, 72, 36, 23, 62, 7, -17],
+        [-47, 60, 37, 65, 84, 129, 73, 44],
+        [-9, 17, 19, 53, 37, 69, 18, 22],
+        [-13, 4, 16, 13, 28, 19, 21, -8],
+        [-23, -9, 12, 10, 19, 17, 25, -16],
+        [-29, -53, -12, -3, -1, 18, -14, -19],
+        [-105, -21, -58, -33, -17, -28, -19, -23],
+    ],
+    [
+        [-58, -38, -13, -28, -31, -27, -63, -99],
+        [-25, -8, -25, -2, -9, -25, -24, -52],
+        [-24, -20, 10, 9, -1, -9, -19, -41],
+        [-17, 3, 22, 22, 22, 11, 8, -18],
+        [-18, -6, 16, 25, 16, 17, 4, -18],
+        [-23, -3, -1, 15, 10, -3, -20, -22],
+        [-42, -20, -10, -5, -2, -20, -23, -44],
+        [-29, -51, -23, -15, -22, -18, -50, -64],
+    ],
 ];
 
-const BISHOP_TABLE: [[i32; 8]; 8] = [
-    [-20, -10, -10, -10, -10, -10, -10, -20],
-    [-10, 0, 0, 0, 0, 0, 0, -10],
-    [-10, 0, 5, 10, 10, 5, 0, -10],
-    [-10, 5, 5, 10, 10, 5, 5, -10],
-    [-10, 0, 10, 10, 10, 10, 0, -10],
-    [-10, 10, 10, 10, 10, 10, 10, -10],
-    [-10, 5, 0, 0, 0, 0, 5, -10],
-    [-20, -10, -10, -10, -10, -10, -10, -20],
+const BISHOP_TABLE: [[[i32; 8]; 8]; 2] = [
+    [
+        [-29, 4, -82, -37, -25, -42, 7, -8],
+        [-26, 16, -18, -13, 30, 59, 18, -47],
+        [-16, 37, 43, 40, 35, 50, 37, -2],
+        [-4, 5, 19, 50, 37, 37, 7, -2],
+        [-6, 13, 13, 26, 34, 12, 10, 4],
+        [0, 15, 15, 15, 14, 27, 18, 10],
+        [4, 15, 16, 0, 7, 21, 33, 1],
+        [-33, -3, -14, -21, -13, -12, -39, -21],
+    ],
+    [
+        [-14, -21, -11, -8, -7, -9, -17, -24],
+        [-8, -4, 7, -12, -3, -13, -4, -14],
+        [2, -8, 0, -1, -2, 6, 0, 4],
+        [-3, 9, 12, 9, 14, 10, 3, 2],
+        [-6, 3, 13, 19, 7, 10, -3, -9],
+        [-12, -3, 8, 10, 13, 3, -7, -15],
+        [-14, -18, -7, -1, 4, -9, -15, -27],
+        [-23, -9, -23, -5, -9, -16, -5, -17],
+    ],
 ];
 
-const ROOK_TABLE: [[i32; 8]; 8] = [
-    [0, 0, 0, 0, 0, 0, 0, 0],
-    [5, 10, 10, 10, 10, 10, 10, 5],
-    [-5, 0, 0, 0, 0, 0, 0, -5],
-    [-5, 0, 0, 0, 0, 0, 0, -5],
-    [-5, 0, 0, 0, 0, 0, 0, -5],
-    [-5, 0, 0, 0, 0, 0, 0, -5],
-    [-5, 0, 0, 0, 0, 0, 0, -5],
-    [0, 0, 0, 5, 5, 0, 0, 0],
+const ROOK_TABLE: [[[i32; 8]; 8]; 2] = [
+    [
+        [32, 42, 32, 51, 63, 9, 31, 43],
+        [27, 32, 58, 62, 80, 67, 26, 44],
+        [-5, 19, 26, 36, 17, 45, 61, 16],
+        [-24, -11, 7, 26, 24, 35, -8, -20],
+        [-36, -26, -12, -1, 9, -7, 6, -23],
+        [-45, -25, -16, -17, 3, 0, -5, -33],
+        [-44, -16, -20, -9, -1, 11, -6, -71],
+        [-19, -13, 1, 17, 16, 7, -37, -26],
+    ],
+    [
+        [13, 10, 18, 15, 12, 12, 8, 5],
+        [11, 13, 13, 11, -3, 3, 8, 3],
+        [7, 7, 7, 5, 4, -3, -5, -3],
+        [4, 3, 13, 1, 2, 1, -1, 2],
+        [3, 5, 8, 4, -5, -6, -8, -11],
+        [-4, 0, -5, -1, -7, -12, -8, -16],
+        [-6, -6, 0, 2, -9, -9, -11, -3],
+        [-9, 2, 3, -1, -5, -13, 4, -20],
+    ],
 ];
-const QUEEN_TABLE: [[i32; 8]; 8] = [
-    [-20, -10, -10, -5, -5, -10, -10, -20],
-    [-10, 0, 0, 0, 0, 0, 0, -10],
-    [-10, 0, 5, 5, 5, 5, 0, -10],
-    [-5, 0, 5, 5, 5, 5, 0, -5],
-    [0, 0, 5, 5, 5, 5, 0, -5],
-    [-10, 5, 5, 5, 5, 5, 0, -10],
-    [-10, 0, 5, 0, 0, 0, 0, -10],
-    [-20, -10, -10, -5, -5, -10, -10, -20],
+const QUEEN_TABLE: [[[i32; 8]; 8]; 2] = [
+    [
+        [-28, 0, 29, 12, 59, 44, 43, 45],
+        [-24, -39, -5, 1, -16, 57, 28, 54],
+        [-13, -17, 7, 8, 29, 56, 47, 57],
+        [-27, -27, -16, -16, -1, 17, -2, 1],
+        [-9, -26, -9, -10, -2, -4, 3, -3],
+        [-14, 2, -11, -2, -5, 2, 14, 5],
+        [-35, -8, 11, 2, 8, 15, -3, 1],
+        [-1, -18, -9, 10, -15, -25, -31, -50],
+    ],
+    [
+        [-9, 22, 22, 27, 27, 19, 10, 20],
+        [-17, 20, 32, 41, 58, 25, 30, 0],
+        [-20, 6, 9, 49, 47, 35, 19, 9],
+        [3, 22, 24, 45, 57, 40, 57, 36],
+        [-18, 28, 19, 47, 31, 34, 39, 23],
+        [-16, -27, 15, 6, 9, 17, 10, 5],
+        [-22, -23, -30, -16, -16, -23, -36, -32],
+        [-33, -28, -22, -43, -5, -32, -20, -41],
+    ],
 ];
 
-const KING_TABLE: [[i32; 8]; 8] = [
-    [-30, -40, -40, -50, -50, -40, -40, -30],
-    [-30, -40, -40, -50, -50, -40, -40, -30],
-    [-30, -40, -40, -50, -50, -40, -40, -30],
-    [-30, -40, -40, -50, -50, -40, -40, -30],
-    [-20, -30, -30, -40, -40, -30, -30, -20],
-    [-10, -20, -20, -20, -20, -20, -20, -10],
-    [20, 20, 0, 0, 0, 0, 20, 20],
-    [20, 30, 10, 0, 0, 10, 30, 20],
-];
-
-const KING_TABLE_ENDGAME: [[i32; 8]; 8] = [
-    [-50, -40, -30, -20, -20, -30, -40, -50],
-    [-30, -20, -10, 0, 0, -10, -20, -30],
-    [-30, -10, 20, 30, 30, 20, -10, -30],
-    [-30, -10, 30, 40, 40, 30, -10, -30],
-    [-30, -10, 30, 40, 40, 30, -10, -30],
-    [-30, -10, 20, 30, 30, 20, -10, -30],
-    [-30, -30, 0, 0, 0, 0, -30, -30],
-    [-50, -30, -30, -30, -30, -30, -30, -50],
+const KING_TABLE: [[[i32; 8]; 8]; 2] = [
+    [
+        [-65, 23, 16, -15, -56, -34, 2, 13],
+        [29, -1, -20, -7, -8, -4, -38, -29],
+        [-9, 24, 2, -16, -20, 6, 22, -22],
+        [-17, -20, -12, -27, -30, -25, -14, -36],
+        [-49, -1, -27, -39, -46, -44, -33, -51],
+        [-14, -14, -22, -46, -44, -30, -15, -27],
+        [1, 7, -8, -64, -43, -16, 9, 8],
+        [-15, 36, 12, -54, 8, -28, 24, 14],
+    ],
+    [
+        [-74, -35, -18, -18, -11, 15, 4, -17],
+        [-12, 17, 14, 17, 17, 38, 23, 11],
+        [10, 17, 23, 15, 20, 45, 44, 13],
+        [-8, 22, 24, 27, 26, 33, 26, 3],
+        [-18, -4, 21, 24, 27, 23, 9, -11],
+        [-19, -3, 11, 21, 23, 16, 7, -9],
+        [-27, -11, 4, 13, 14, 4, -5, -17],
+        [-53, -34, -21, -11, -28, -14, -24, -43],
+    ],
 ];
 
 pub const MATE: i32 = 1_000_000;
 
-const ENDGAME_MATERIAL: i32 = 2 * KNIGHT_SCORE + 2 * BISHOP_SCORE + 2 * ROOK_SCORE + QUEEN_SCORE;
-
-fn interpolate(t1: [[i32; 8]; 8], t2: [[i32; 8]; 8], f: f32) -> [[i32; 8]; 8] {
-    let mut result = [[0; 8]; 8];
-    for i in 0..8 {
-        for j in 0..8 {
-            result[i][j] = (t1[i][j] as f32 * (1.0 - f) + t2[i][j] as f32 * f) as i32;
-        }
-    }
-    result
-}
-
 pub fn score(board: &Board) -> i32 {
-    let mut score = 0;
-    let mut white_endgame_score = 0;
-    let mut black_endgame_score = 0;
+    let mut wpawns = 0;
+    let mut bpawns = 0;
+    let mut wknights = 0;
+    let mut bknights = 0;
+    let mut wbishops = 0;
+    let mut bbishops = 0;
+    let mut wrooks = 0;
+    let mut brooks = 0;
+    let mut wqueens = 0;
+    let mut bqueens = 0;
 
-    for row in board.board.iter() {
-        for cell in row.iter() {
-            match cell.kind() {
-                Piece::PAWN => {
-                    score += PAWN_SCORE * if cell.side() == Piece::WHITE { 1 } else { -1 };
-                }
-                Piece::KNIGHT => {
-                    score += KNIGHT_SCORE * if cell.side() == Piece::WHITE { 1 } else { -1 };
-                    match cell.side() {
-                        Piece::WHITE => {
-                            white_endgame_score += KNIGHT_SCORE;
-                        }
-                        Piece::BLACK => {
-                            black_endgame_score += KNIGHT_SCORE;
-                        }
-                        _ => {}
-                    }
-                }
-                Piece::BISHOP => {
-                    score += BISHOP_SCORE * if cell.side() == Piece::WHITE { 1 } else { -1 };
-                    match cell.side() {
-                        Piece::WHITE => {
-                            white_endgame_score += BISHOP_SCORE;
-                        }
-                        Piece::BLACK => {
-                            black_endgame_score += BISHOP_SCORE;
-                        }
-                        _ => {}
-                    }
-                }
-                Piece::ROOK => {
-                    score += ROOK_SCORE * if cell.side() == Piece::WHITE { 1 } else { -1 };
-                    match cell.side() {
-                        Piece::WHITE => {
-                            white_endgame_score += ROOK_SCORE;
-                        }
-                        Piece::BLACK => {
-                            black_endgame_score += ROOK_SCORE;
-                        }
-                        _ => {}
-                    }
-                }
-                Piece::QUEEN => {
-                    score += QUEEN_SCORE * if cell.side() == Piece::WHITE { 1 } else { -1 };
-                    match cell.side() {
-                        Piece::WHITE => {
-                            white_endgame_score += QUEEN_SCORE;
-                        }
-                        Piece::BLACK => {
-                            black_endgame_score += QUEEN_SCORE;
-                        }
-                        _ => {}
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    let white_endgame_weight =
-        1. - f32::min(1., white_endgame_score as f32 / ENDGAME_MATERIAL as f32);
-
-    let black_endgame_weight =
-        1. - f32::min(1., black_endgame_score as f32 / ENDGAME_MATERIAL as f32);
+    let mut psqt_mg_score = 0;
+    let mut psqt_eg_score = 0;
 
     for (r_idx, row) in board.board.iter().enumerate() {
         for (c_idx, cell) in row.iter().enumerate() {
-            let r_corr = if cell.side() == Piece::WHITE {
-                7 - r_idx
-            } else {
-                r_idx
-            };
-            match cell.kind() {
-                Piece::PAWN => match cell.side() {
-                    Piece::WHITE => {
-                        score += interpolate(PAWN_TABLE, PAWN_TABLE_ENDGAME, white_endgame_weight)
-                            [r_corr][c_idx]
-                            * if cell.side() == Piece::WHITE { 1 } else { -1 }
-                    }
-                    Piece::BLACK => {
-                        score += interpolate(PAWN_TABLE, PAWN_TABLE_ENDGAME, black_endgame_weight)
-                            [r_corr][c_idx]
-                            * if cell.side() == Piece::WHITE { 1 } else { -1 }
-                    }
-                    _ => {}
-                },
-                Piece::KNIGHT => {
-                    score += KNIGHT_TABLE[r_corr][c_idx]
-                        * if cell.side() == Piece::WHITE { 1 } else { -1 };
+            match (cell.kind(), cell.side()) {
+                (Piece::PAWN, Piece::WHITE) => {
+                    wpawns += 1;
+                    psqt_mg_score += PAWN_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score += PAWN_TABLE[1][r_idx][c_idx];
                 }
-                Piece::BISHOP => {
-                    score += BISHOP_TABLE[r_corr][c_idx]
-                        * if cell.side() == Piece::WHITE { 1 } else { -1 };
+                (Piece::PAWN, Piece::BLACK) => {
+                    bpawns += 1;
+                    psqt_mg_score += PAWN_TABLE[0][7 - r_idx][c_idx];
+                    psqt_eg_score += PAWN_TABLE[1][7 - r_idx][c_idx];
                 }
-                Piece::ROOK => {
-                    score += ROOK_TABLE[r_corr][c_idx]
-                        * if cell.side() == Piece::WHITE { 1 } else { -1 };
+                (Piece::KNIGHT, Piece::WHITE) => {
+                    wknights += 1;
+                    psqt_mg_score += KNIGHT_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score += KNIGHT_TABLE[1][r_idx][c_idx];
                 }
-                Piece::QUEEN => {
-                    score += QUEEN_TABLE[r_corr][c_idx]
-                        * if cell.side() == Piece::WHITE { 1 } else { -1 };
+                (Piece::KNIGHT, Piece::BLACK) => {
+                    bknights += 1;
+                    psqt_mg_score += KNIGHT_TABLE[0][7 - r_idx][c_idx];
+                    psqt_eg_score += KNIGHT_TABLE[1][7 - r_idx][c_idx];
                 }
-                Piece::KING => match cell.side() {
-                    Piece::WHITE => {
-                        score += interpolate(KING_TABLE, KING_TABLE_ENDGAME, white_endgame_weight)
-                            [r_corr][c_idx]
-                            * if cell.side() == Piece::WHITE { 1 } else { -1 };
-                    }
-                    Piece::BLACK => {
-                        score += interpolate(KING_TABLE, KING_TABLE_ENDGAME, black_endgame_weight)
-                            [r_corr][c_idx]
-                            * if cell.side() == Piece::WHITE { 1 } else { -1 };
-                    }
-                    _ => {}
-                },
+                (Piece::BISHOP, Piece::WHITE) => {
+                    wbishops += 1;
+                    psqt_mg_score += BISHOP_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score += BISHOP_TABLE[1][r_idx][c_idx];
+                }
+                (Piece::BISHOP, Piece::BLACK) => {
+                    bbishops += 1;
+                    psqt_mg_score += BISHOP_TABLE[0][7 - r_idx][c_idx];
+                    psqt_eg_score += BISHOP_TABLE[1][7 - r_idx][c_idx];
+                }
+                (Piece::ROOK, Piece::WHITE) => {
+                    wrooks += 1;
+                    psqt_mg_score += ROOK_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score += ROOK_TABLE[1][r_idx][c_idx];
+                }
+                (Piece::ROOK, Piece::BLACK) => {
+                    brooks += 1;
+                    psqt_mg_score += ROOK_TABLE[0][7 - r_idx][c_idx];
+                    psqt_eg_score += ROOK_TABLE[1][7 - r_idx][c_idx];
+                }
+                (Piece::QUEEN, Piece::WHITE) => {
+                    wqueens += 1;
+                    psqt_mg_score += QUEEN_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score += QUEEN_TABLE[1][r_idx][c_idx];
+                }
+                (Piece::QUEEN, Piece::BLACK) => {
+                    bqueens += 1;
+                    psqt_mg_score += QUEEN_TABLE[0][7 - r_idx][c_idx];
+                    psqt_eg_score += QUEEN_TABLE[1][7 - r_idx][c_idx];
+                }
+                (Piece::KING, Piece::WHITE) => {
+                    psqt_mg_score += KING_TABLE[0][r_idx][c_idx];
+                    psqt_eg_score += KING_TABLE[1][r_idx][c_idx];
+                }
+                (Piece::KING, Piece::BLACK) => {
+                    psqt_mg_score += KING_TABLE[0][7 - r_idx][c_idx];
+                    psqt_eg_score += KING_TABLE[1][7 - r_idx][c_idx];
+                }
                 _ => {}
             }
         }
     }
+
+    let eval_mg = (wpawns - bpawns) * PIECE_VALUES[0][0]
+        + (wknights - bknights) * PIECE_VALUES[0][1]
+        + (wbishops - bbishops) * PIECE_VALUES[0][2]
+        + (wrooks - brooks) * PIECE_VALUES[0][3]
+        + (wqueens - bqueens) * PIECE_VALUES[0][4]
+        + psqt_mg_score;
+
+    let eval_eg = (wpawns - bpawns) * PIECE_VALUES[1][0]
+        + (wknights - bknights) * PIECE_VALUES[1][1]
+        + (wbishops - bbishops) * PIECE_VALUES[1][2]
+        + (wrooks - brooks) * PIECE_VALUES[1][3]
+        + (wqueens - bqueens) * PIECE_VALUES[1][4]
+        + psqt_eg_score;
+
+    let phase = 24
+        - (wknights
+            + bknights
+            + wbishops
+            + bbishops
+            + 2 * (wrooks + brooks)
+            + 4 * (wqueens + bqueens));
+
+    let phase = (phase * 256 + 12) / 24;
+
+    let score = (eval_mg * (256 - phase) + eval_eg * phase) / 256;
 
     if board.is_white_turn {
         score


### PR DESCRIPTION
```
Results of alex/psqt vs main (10+0.1, 1t, 128MB, 8moves_v3.pgn):
Elo: 101.81 +/- 29.79, nElo: 130.54 +/- 35.99
LOS: 100.00 %, DrawRatio: 34.64 %, PairsRatio: 3.33
Games: 358, Wins: 169, Losses: 67, Draws: 122, Points: 230.0 (64.25 %)
Ptnml(0-2): [5, 22, 62, 46, 44]
LLR: 2.95 (-2.94, 2.94) [0.00, 10.00]
```